### PR TITLE
Update from Cat(a, Cat(b, Cat(c, d))) to Cat(a, b, c, d)

### DIFF
--- a/04_instruction_decoder/soc.py
+++ b/04_instruction_decoder/soc.py
@@ -62,11 +62,9 @@ class SOC(Elaboratable):
         # Immediate format decoder
         Uimm = (Cat(Repl(0, 12), instr[12:32]))
         Iimm = (Cat(instr[20:31], Repl(instr[31], 21)))
-        Simm = (Cat(instr[7:12], Cat(instr[25:31], Repl(instr[31], 21)))),
-        Bimm = (Cat(0, Cat(instr[8:12], Cat(instr[25:31], Cat(
-            instr[7], Repl(instr[31], 20))))))
-        Jimm = (Cat(0, Cat(instr[21:31], Cat(instr[20], Cat(
-            instr[12:20], Repl(instr[31], 12))))))
+        Simm = (Cat(instr[7:12], instr[25:31], Repl(instr[31], 21))),
+        Bimm = (Cat(0, instr[8:12], instr[25:31], instr[7], Repl(instr[31], 20)))
+        Jimm = (Cat(0, instr[21:31], instr[20], instr[12:20], Repl(instr[31], 12)))
 
         # Register addresses decoder
         rs1Id = (instr[15:20])
@@ -84,8 +82,8 @@ class SOC(Elaboratable):
         ]
 
         # Assign important signals to LEDS
-        m.d.comb += self.leds.eq(Mux(isSystem, 31, Cat(isLoad, Cat(
-            isStore, Cat(isALUimm, Cat(isALUreg, pc[0]))))))
+        m.d.comb += self.leds.eq(Mux(isSystem, 31,
+            Cat(isLoad, isStore, isALUimm, isALUreg, pc[0])))
 
         # Export signals for simulation
         def export(signal, name):

--- a/05_register_bank/soc.py
+++ b/05_register_bank/soc.py
@@ -70,11 +70,9 @@ class SOC(Elaboratable):
         # Immediate format decoder
         Uimm = (Cat(Repl(0, 12), instr[12:32]))
         Iimm = (Cat(instr[20:31], Repl(instr[31], 21)))
-        Simm = (Cat(instr[7:12], Cat(instr[25:31], Repl(instr[31], 21)))),
-        Bimm = (Cat(0, Cat(instr[8:12], Cat(instr[25:31], Cat(
-            instr[7], Repl(instr[31], 20))))))
-        Jimm = (Cat(0, Cat(instr[21:31], Cat(instr[20], Cat(
-            instr[12:20], Repl(instr[31], 12))))))
+        Simm = (Cat(instr[7:12], instr[25:31], Repl(instr[31], 21))),
+        Bimm = (Cat(0, instr[8:12], instr[25:31], instr[7], Repl(instr[31], 20)))
+        Jimm = (Cat(0, instr[21:31], instr[20], instr[12:20], Repl(instr[31], 12)))
 
         # Register addresses decoder
         rs1Id = (instr[15:20])

--- a/06_alu/soc.py
+++ b/06_alu/soc.py
@@ -107,11 +107,9 @@ class SOC(Elaboratable):
         # Immediate format decoder
         Uimm = (Cat(Repl(0, 12), instr[12:32]))
         Iimm = (Cat(instr[20:31], Repl(instr[31], 21)))
-        Simm = (Cat(instr[7:12], Cat(instr[25:31], Repl(instr[31], 21)))),
-        Bimm = (Cat(0, Cat(instr[8:12], Cat(instr[25:31], Cat(
-            instr[7], Repl(instr[31], 20))))))
-        Jimm = (Cat(0, Cat(instr[21:31], Cat(instr[20], Cat(
-            instr[12:20], Repl(instr[31], 12))))))
+        Simm = (Cat(instr[7:12], instr[25:31], Repl(instr[31], 21))),
+        Bimm = (Cat(0, instr[8:12], instr[25:31], instr[7], Repl(instr[31], 20)))
+        Jimm = (Cat(0, instr[21:31], instr[20], instr[12:20], Repl(instr[31], 12)))
 
         # Register addresses decoder
         rs1Id = (instr[15:20])

--- a/07_assembler/soc.py
+++ b/07_assembler/soc.py
@@ -73,16 +73,14 @@ class SOC(Elaboratable):
         # Immediate format decoder
         Uimm = (Cat(Repl(0, 12), instr[12:32]))
         Iimm = (Cat(instr[20:31], Repl(instr[31], 21)))
-        Simm = (Cat(instr[7:12], Cat(instr[25:31], Repl(instr[31], 21)))),
-        Bimm = (Cat(0, Cat(instr[8:12], Cat(instr[25:31], Cat(
-            instr[7], Repl(instr[31], 20))))))
-        Jimm = (Cat(0, Cat(instr[21:31], Cat(instr[20], Cat(
-            instr[12:20], Repl(instr[31], 12))))))
+        Simm = (Cat(instr[7:12], instr[25:31], Repl(instr[31], 21))),
+        Bimm = (Cat(0, instr[8:12], instr[25:31], instr[7], Repl(instr[31], 20)))
+        Jimm = (Cat(0, instr[21:31], instr[20], instr[12:20], Repl(instr[31], 12)))
 
         # Register addresses decoder
         rs1Id = (instr[15:20])
         rs2Id = (instr[20:25])
-        rdId = ( instr[7:12])
+        rdId =  (instr[7:12])
 
         # Function code decdore
         funct3 = (instr[12:15])

--- a/08_jumps/soc.py
+++ b/08_jumps/soc.py
@@ -65,11 +65,9 @@ class SOC(Elaboratable):
         # Immediate format decoder
         Uimm = (Cat(Repl(0, 12), instr[12:32]))
         Iimm = (Cat(instr[20:31], Repl(instr[31], 21)))
-        Simm = (Cat(instr[7:12], Cat(instr[25:31], Repl(instr[31], 21)))),
-        Bimm = (Cat(0, Cat(instr[8:12], Cat(instr[25:31], Cat(
-            instr[7], Repl(instr[31], 20))))))
-        Jimm = (Cat(0, Cat(instr[21:31], Cat(instr[20], Cat(
-            instr[12:20], Repl(instr[31], 12))))))
+        Simm = (Cat(instr[7:12], instr[25:31], Repl(instr[31], 21))),
+        Bimm = (Cat(0, instr[8:12], instr[25:31], instr[7], Repl(instr[31], 20)))
+        Jimm = (Cat(0, instr[21:31], instr[20], instr[12:20], Repl(instr[31], 12)))
 
         # Register addresses decoder
         rs1Id = (instr[15:20])

--- a/09_branches/soc.py
+++ b/09_branches/soc.py
@@ -67,16 +67,14 @@ class SOC(Elaboratable):
         # Immediate format decoder
         Uimm = (Cat(Repl(0, 12), instr[12:32]))
         Iimm = (Cat(instr[20:31], Repl(instr[31], 21)))
-        Simm = (Cat(instr[7:12], Cat(instr[25:31], Repl(instr[31], 21)))),
-        Bimm = (Cat(0, Cat(instr[8:12], Cat(instr[25:31], Cat(
-            instr[7], Repl(instr[31], 20))))))
-        Jimm = (Cat(0, Cat(instr[21:31], Cat(instr[20], Cat(
-            instr[12:20], Repl(instr[31], 12))))))
+        Simm = (Cat(instr[7:12], instr[25:31], Repl(instr[31], 21))),
+        Bimm = (Cat(0, instr[8:12], instr[25:31], instr[7], Repl(instr[31], 20)))
+        Jimm = (Cat(0, instr[21:31], instr[20], instr[12:20], Repl(instr[31], 12)))
 
         # Register addresses decoder
         rs1Id = (instr[15:20])
         rs2Id = (instr[20:25])
-        rdId = ( instr[7:12])
+        rdId =  (instr[7:12])
 
         # Function code decdore
         funct3 = (instr[12:15])

--- a/10_lui_auipc/soc.py
+++ b/10_lui_auipc/soc.py
@@ -64,11 +64,9 @@ class SOC(Elaboratable):
         # Immediate format decoder
         Uimm = (Cat(Const(0, 12), instr[12:32]))
         Iimm = (Cat(instr[20:31], Repl(instr[31], 21)))
-        Simm = (Cat(instr[7:12], Cat(instr[25:31], Repl(instr[31], 21)))),
-        Bimm = (Cat(0, Cat(instr[8:12], Cat(instr[25:31], Cat(
-            instr[7], Repl(instr[31], 20))))))
-        Jimm = (Cat(0, Cat(instr[21:31], Cat(instr[20], Cat(
-            instr[12:20], Repl(instr[31], 12))))))
+        Simm = (Cat(instr[7:12], instr[25:31], Repl(instr[31], 21))),
+        Bimm = (Cat(0, instr[8:12], instr[25:31], instr[7], Repl(instr[31], 20)))
+        Jimm = (Cat(0, instr[21:31], instr[20], instr[12:20], Repl(instr[31], 12)))
 
         # Register addresses decoder
         rs1Id = (instr[15:20])


### PR DESCRIPTION
It seems like it works in Amaranth, and since is among the first few sources I read, adjusting it here might help other people to get it right from the start.

Or maybe it was intentional?

I generated logs for each benchtests.
```sh
git checkout 975f018
git diff --stat 7807bd6  | while IFS='/ ' read test _; do echo $test; (cd $test; python ./bench.py >commit_975f018.log); done
git checkout 7807bd6
git diff --stat 975f018 | while IFS='/ ' read test _; do echo $test; (cd $test; python ./bench.py >commit_7807bd6.log); done
```

I then compared the output from each commit and it reported nothing
```
git diff --stat 975f018 | grep '|' | while IFS='/ ' read test _; do diff -u $test/commit_*.log; done
```